### PR TITLE
Operator 0.0.6

### DIFF
--- a/argocd-operator/base/argocd-subscription.yaml
+++ b/argocd-operator/base/argocd-subscription.yaml
@@ -4,8 +4,8 @@ metadata:
   name: argocd-operator
 spec:
   channel: alpha
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: argocd-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: argocd-operator.v0.0.5
+  startingCSV: argocd-operator.v0.0.6

--- a/argocd/base/argocd.yaml
+++ b/argocd/base/argocd.yaml
@@ -3,8 +3,10 @@ kind: ArgoCD
 metadata:
   name: argocd
   labels:
-    example: defaults
+    profile: redhat-canada-gitops
 spec:
+  server:
+    route: true
   dex:
     image: quay.io/ablock/dex
     version: openshift-connector

--- a/setup.sh
+++ b/setup.sh
@@ -7,16 +7,17 @@ echo "Installing Argo CD Operator."
 
 oc apply -k argocd-operator/overlays/default
 
-echo "Pause 5 seconds for the creation of the InstallPlan."
-sleep 5
+echo "Pause 10 seconds for the creation of the InstallPlan."
+sleep 10
 
 echo "Approving operator installation."
 IPNAME=$(oc get installplan -n argocd -o jsonpath='{range .items[*].metadata}{.name}{end}')
+echo "($IPNAME)"
 oc patch installplan $IPNAME --type=json -p='[{"op":"replace","path": "/spec/approved", "value": true}]'
 
-echo "Pausing for 15 seconds for operator initialization..."
+echo "Pausing for 10 seconds for operator initialization..."
 
-sleep 15
+sleep 10
 
 oc rollout status deploy/argocd-operator -n argocd
 

--- a/setup.sh
+++ b/setup.sh
@@ -7,6 +7,13 @@ echo "Installing Argo CD Operator."
 
 oc apply -k argocd-operator/overlays/default
 
+echo "Pause 5 seconds for the creation of the InstallPlan."
+sleep 5
+
+echo "Approving operator installation."
+IPNAME=$(oc get installplan -n argocd -o jsonpath='{range .items[*].metadata}{.name}{end}')
+oc patch installplan $IPNAME --type=json -p='[{"op":"replace","path": "/spec/approved", "value": true}]'
+
 echo "Pausing for 15 seconds for operator initialization..."
 
 sleep 15


### PR DESCRIPTION
Updated operator to version 0.0.6, which also bumps Argo CD up to 1.5.1.

The operator is now set to "Manual" install plan.  The setup script will pause for a few seconds after creating the Subscription and OperatorGroup to wait for the InstallPlan to be created, then it will approve the install.

Also added the the "server" stanza to the argocd.yaml custom resource, as it is now required if you want a route created.